### PR TITLE
Add rate limiter for POST /ipc.

### DIFF
--- a/app/config/custom-environment-variables.json
+++ b/app/config/custom-environment-variables.json
@@ -26,7 +26,13 @@
     },
     "logLevel": "SERVER_LOGLEVEL",
     "morganFormat": "SERVER_MORGANFORMAT",
-    "port": "SERVER_PORT"
+    "port": "SERVER_PORT",
+    "rateLimit" : {
+      "ipc": {
+        "windowMs": "SERVER_RATELIMIT_IPC_WINDOWMS",
+        "max": "SERVER_RATELIMIT_IPC_MAX"
+      }
+    }
   },
   "serviceClient": {
     "commonServices": {

--- a/app/config/default.json
+++ b/app/config/default.json
@@ -23,7 +23,13 @@
     },
     "logLevel": "debug",
     "morganFormat": "combined",
-    "port": "8080"
+    "port": "8080",
+    "rateLimit" : {
+      "ipc": {
+        "windowMs": "900000",
+        "max": "100"
+      }
+    }
   },
   "serviceClient": {
     "commonServices": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -4074,6 +4074,11 @@
         }
       }
     },
+    "express-rate-limit": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.1.1.tgz",
+      "integrity": "sha512-puA1zcCx/quwWUOU6pT6daCt6t7SweD9wKChKhb+KSgFMKRwS81C224hiSAUANw/gnSHiwEhgozM/2ezEBZPeA=="
+    },
     "express-validator": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.4.0.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -52,6 +52,7 @@
     "compression": "^1.7.4",
     "config": "^3.3.1",
     "express": "^4.17.1",
+    "express-rate-limit": "^5.1.1",
     "express-validator": "^6.4.0",
     "js-yaml": "^3.13.1",
     "jsonwebtoken": "^8.5.1",

--- a/app/src/routes/v1/ipc.js
+++ b/app/src/routes/v1/ipc.js
@@ -1,13 +1,19 @@
+const config = require('config');
+const log = require('npmlog');
+const Problem = require('api-problem');
+const rateLimit = require('express-rate-limit');
 const router = require('express').Router();
 
 const Constants = require('../../components/constants');
-const log = require('npmlog');
-const Problem = require('api-problem');
 const validation = require('../../middleware/validation');
-
 const db = require('../../models');
 
-router.post('/', validation.validateIPC, async (req, res) => {
+const ipcRateLimiter = rateLimit({
+  windowMs: config.get('server.rateLimit.ipc.windowMs'),
+  max: config.get('server.rateLimit.ipc.max')
+});
+
+router.post('/', ipcRateLimiter, validation.validateIPC, async (req, res) => {
 
   try {
     const body = req.body;

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -39,7 +39,9 @@ oc create -n $NAMESPACE configmap silvipc-server-config \
   --from-literal=SERVER_KC_SERVERURL=https://sso-dev.pathfinder.gov.bc.ca/auth \
   --from-literal=SERVER_LOGLEVEL=info \
   --from-literal=SERVER_MORGANFORMAT=combined \
-  --from-literal=SERVER_PORT=8080
+  --from-literal=SERVER_PORT=8080 \
+  --from-literal=SERVER_RATELIMIT_IPC_WINDOWMS=600000 \
+  --from-literal=SERVER_RATELIMIT_IPC_MAX=10
 ```
 
 ### Secrets


### PR DESCRIPTION
Configurable, default to allow 10 requests in 10 minutes (600000 ms) from a single IP.
Config Map is updated on DEV