### PR TITLE
Add OrgBook typeahead search for business registration name

### DIFF
--- a/app/config/custom-environment-variables.json
+++ b/app/config/custom-environment-variables.json
@@ -12,6 +12,9 @@
       "clientId": "FRONTEND_KC_CLIENTID",
       "realm": "FRONTEND_KC_REALM",
       "serverUrl": "FRONTEND_KC_SERVERURL"
+    },
+    "orgbook": {
+      "endpoint": "ORGBOOK_API_ENDPOINT"
     }
   },
   "server": {

--- a/app/config/default.json
+++ b/app/config/default.json
@@ -10,6 +10,9 @@
       "clientId": "silvipc-frontend",
       "realm": "cp1qly2d",
       "serverUrl": "https://sso-dev.pathfinder.gov.bc.ca/auth"
+    },
+    "orgbook": {
+      "endpoint": "https://orgbook.gov.bc.ca/api/v2"
     }
   },
   "server": {

--- a/app/frontend/src/components/form/OrgBookSearch.vue
+++ b/app/frontend/src/components/form/OrgBookSearch.vue
@@ -1,0 +1,91 @@
+<template>
+  <v-autocomplete
+    dense
+    outlined
+    flat
+    solo
+    v-model="model"
+    :rules="rules"
+    :items="items"
+    :loading="isLoading"
+    :search-input.sync="search"
+    :change="emitChange"
+    hide-no-data
+    hide-selected
+    label="OrgBook Lookup"
+    placeholder="Start typing to search the OrgBook database"
+    prepend-icon="mdi-database-search"
+    append-icon=""
+  ></v-autocomplete>
+</template>
+
+<script>
+import Vue from 'vue';
+
+export default {
+  name: 'OrgBookSearch',
+  props: {
+    fieldModel: String,
+    fieldRules: Array,
+  },
+  data() {
+    return {
+      isLoading: false,
+      entries: [],
+      search: null,
+      model: this.fieldModel,
+      rules: this.fieldRules,
+    };
+  },
+  computed: {
+    items() {
+      return this.entries.map((entry) => {
+        // there will only ever be 1 result in the names array
+        return Object.assign({
+          text: entry.names[0].text,
+          value: entry.names[0].text,
+        });
+      });
+    },
+    apiURL() {
+      if (Vue.prototype.$config) {
+        const config = Vue.prototype.$config;
+        return config.orgbook.endpoint;
+      } else {
+        throw new Error('Configuration object is missing.');
+      }
+    },
+  },
+  methods: {
+    emitChange: function () {
+      this.$emit('field-model', this.fieldModel);
+    },
+  },
+  watch: {
+    search(val) {
+      // Minimum search length is 3 characters
+      if (!val || val.length < 3) return;
+
+      // A search has already been started
+      if (this.isLoading) return;
+
+      this.isLoading = true;
+
+      // Lazily load results
+      fetch(
+        `${this.apiURL}/search/autocomplete?q=${val}&inactive=false&latest=true&revoked=false`
+      )
+        .then((res) => res.json())
+        .then((res) => {
+          this.count = res.results.length;
+          this.entries = res.results;
+        })
+        .catch((err) => {
+          // eslint-disable-next-line
+          console.log(err);
+        })
+        .finally(() => (this.isLoading = false));
+    },
+  },
+};
+</script>

--- a/app/frontend/src/components/form/Step2.vue
+++ b/app/frontend/src/components/form/Step2.vue
@@ -10,13 +10,9 @@
         <v-row>
           <v-col cols="12" lg="10">
             <h4 class="mb-1">Registered Business Name</h4>
-            <v-text-field
-              dense
-              outlined
-              flat
-              solo
-              v-model="businessName"
-              :rules="businessNameRules"
+            <OrgBookSearch
+              :field-model="businessName"
+              :field-rules="businessNameRules"
             />
           </v-col>
         </v-row>
@@ -193,10 +189,15 @@
 import validator from 'validator';
 import { mapGetters, mapMutations } from 'vuex';
 
+import OrgBookSearch from '@/components/form/OrgBookSearch.vue';
+
 export default {
   name: 'Step2',
   props: {
     reviewMode: Boolean
+  },
+  components: {
+    OrgBookSearch
   },
   data() {
     return {

--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -70,6 +70,10 @@ async function loadConfig() {
     }
     await loadKeycloak(config);
     kcSuccess = true;
+
+    if (!config || !config.orgbook || !config.orgbook.endpoint) {
+      throw new Error('OrgBook API is misconfigured');
+    }
   } catch (err) {
     sessionStorage.removeItem(storageKey);
     throw new Error(`Failed to acquire configuration: ${err.message}`);


### PR DESCRIPTION
Enhance the registration form by adding a lookup for the `Registered Business Name`: the results are fetched from OrgBookBC, which exposes data about businesses registered in British Columbia.

New settings have been added to `custom-environment-variables.json` and `default.json` to support the change. The API is currently set to point to the PROD instance of OrgBook by default since dev and test do not have data for all businesses.

However, if preferable, the `dev` and `test` instances could be used:
- https://dev.orgbook.gov.bc.ca
- https://test.orgbook.gov.bc.ca

The search is currently using the `APIv2` endpoints, updating to the new `APIv3` (when available) will be as easy as re-mapping the mappings in the computed property `items` (for a preview of the `APIv3` search endpoint refer to https://orgbook-prod.pathfinder.gov.bc.ca/api/v3/).