### PR TITLE
Correctly emit value on autocomplete model change

### DIFF
--- a/app/frontend/src/components/form/OrgBookSearch.vue
+++ b/app/frontend/src/components/form/OrgBookSearch.vue
@@ -4,12 +4,12 @@
     outlined
     flat
     solo
+    v-model="model"
     :rules="rules"
     :items="items"
     :loading="isLoading"
     :search-input.sync="search"
-    v-bind:value="value"
-    v-on:change="$emit('change', $event.target.value)"
+    v-on:change="change"
     hide-no-data
     hide-selected
     label="OrgBook Lookup"
@@ -25,7 +25,7 @@ import Vue from 'vue';
 export default {
   name: 'OrgBookSearch',
   props: {
-    value: String,
+    fieldModel: String,
     fieldRules: Array,
   },
   data() {
@@ -33,6 +33,7 @@ export default {
       isLoading: false,
       entries: [],
       search: null,
+      model: this.fieldModel,
       rules: this.fieldRules,
     };
   },
@@ -56,14 +57,14 @@ export default {
     },
   },
   methods: {
-    emitChange: function () {
-      this.$emit('field-model', this.fieldModel);
+    change: function (value) {
+      this.$emit('update:field-model', value);
     },
   },
   watch: {
     search(val) {
-      // Minimum search length is 3 characters
-      if (!val || val.length < 3) return;
+      // Minimum search length is 1 character
+      if (!val || val.length < 1) return;
 
       // A search has already been started
       if (this.isLoading) return;

--- a/app/frontend/src/components/form/Step2.vue
+++ b/app/frontend/src/components/form/Step2.vue
@@ -10,11 +10,13 @@
         <v-row>
           <v-col cols="12" lg="10">
             <h4 class="mb-1">Registered Business Name</h4>
-            <!-- <OrgBookSearch
-              v-model="businessName"
+            <OrgBookSearch
+              v-if="!reviewMode"
+              :field-model.sync="businessName"
               :field-rules="businessNameRules"
-            />-->
+            />
             <v-text-field
+              v-if="reviewMode"
               dense
               flat
               outlined
@@ -192,7 +194,7 @@
 import validator from 'validator';
 import { mapGetters, mapMutations } from 'vuex';
 
-//import OrgBookSearch from '@/components/form/OrgBookSearch.vue';
+import OrgBookSearch from '@/components/form/OrgBookSearch.vue';
 
 export default {
   name: 'Step2',
@@ -200,7 +202,7 @@ export default {
     reviewMode: Boolean
   },
   components: {
-    //OrgBookSearch
+    OrgBookSearch
   },
   data() {
     return {


### PR DESCRIPTION
This fixed the issue where the value of the business name would not be carried over through step 6 (sorry about that, didn't realize going back and forth between step 2 and 3 wasn't actually using the model).

Opted to use the existing textbox rather than the autocomplete when in review mode, as the latter would have required additional checks/tweaks in the autocomplete to make it pick up the stored value again, be readonly and look like the other fields on the page.

I also reduced the minimum search query to one character, as apparently there are some business registration names that are that long (short).