### PR TITLE
Fix for incorrectly escaped special characters in OrgBook search query string

### DIFF
--- a/app/frontend/src/components/form/OrgBookSearch.vue
+++ b/app/frontend/src/components/form/OrgBookSearch.vue
@@ -59,7 +59,8 @@ export default {
   },
   methods: {
     change: function (value) {
-      this.$emit('update:field-model',
+      this.$emit(
+        'update:field-model',
         // For this use, want to emit just the text
         typeof value === 'object' && value !== null ? value.text : value
       );
@@ -77,7 +78,9 @@ export default {
 
       // Lazily load results
       fetch(
-        `${this.apiURL}/search/autocomplete?q=${val}&inactive=false&latest=true&revoked=false`
+        `${this.apiURL}/search/autocomplete?q=${encodeURIComponent(
+          val
+        )}&inactive=false&latest=true&revoked=false`
       )
         .then((res) => res.json())
         .then((res) => {


### PR DESCRIPTION
Fixes a bug that would result in the search results being inaccurate when searching for a company whose name contains special characters.

An example: `K & C Silviculture LTD` would not be displayed in the search results because of the `&` not being escaped and therefore splitting the query string.

The fix is to correctly URL encode the search term.