### PR TITLE
Implement prop based role checking

### DIFF
--- a/app/frontend/src/components/base/BaseSecure.vue
+++ b/app/frontend/src/components/base/BaseSecure.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="authenticated">
-    <div v-if="authorized">
+    <div v-if="authorized()">
       <slot />
     </div>
     <div v-else class="text-center">
@@ -23,6 +23,7 @@
 
 <script>
 import { mapGetters } from 'vuex';
+import { SilvipcRoles } from '@/utils/constants';
 
 export default {
   name: 'BaseSecure',
@@ -30,14 +31,17 @@ export default {
     ...mapGetters('auth', [
       'authenticated',
       'createLoginUrl',
-      'isAdmin',
+      'hasSilvipcRoles',
       'keycloakReady'
-    ]),
-    authorized() {
-      return this.admin ? this.isAdmin : true;
-    }
+    ])
   },
   methods: {
+    authorized() {
+      const roles = [];
+      if (this.developer) roles.push(SilvipcRoles.DEVELOPER);
+      if (this.inspector) roles.push(SilvipcRoles.INSPECTOR);
+      return this.hasSilvipcRoles(roles);
+    },
     login() {
       if (this.keycloakReady) {
         window.location.replace(this.createLoginUrl({ idpHint: 'idir' }));
@@ -45,7 +49,11 @@ export default {
     }
   },
   props: {
-    admin: {
+    developer: {
+      default: false,
+      type: Boolean
+    },
+    inspector: {
       default: false,
       type: Boolean
     }

--- a/app/frontend/src/router/index.js
+++ b/app/frontend/src/router/index.js
@@ -25,20 +25,17 @@ const router = new VueRouter({
           component: () => import(/* webpackChunkName: "submission-table" */ '@/views/admin/Root.vue')
         },
         {
+          path: 'dev',
+          name: 'Dev',
+          component: () => import(/* webpackChunkName: "dev" */ '@/views/admin/Dev.vue'),
+        },
+        {
           path: 'submission/:ipcPlanId',
           name: 'Submission',
           component: () => import(/* webpackChunkName: "submission" */ '@/views/admin/Submission.vue'),
           props: true
         }
       ],
-      meta: {
-        requiresAuth: true
-      }
-    },
-    {
-      path: '/dev',
-      name: 'Dev',
-      component: () => import(/* webpackChunkName: "dev" */ '@/views/Dev.vue'),
       meta: {
         requiresAuth: true
       }

--- a/app/frontend/src/store/modules/auth.js
+++ b/app/frontend/src/store/modules/auth.js
@@ -1,7 +1,5 @@
 import Vue from 'vue';
 
-//import { RealmRoles } from '@/utils/constants';
-
 /**
  * @function hasRoles
  * Checks if all elements in `roles` array exists in `tokenRoles` array
@@ -9,9 +7,9 @@ import Vue from 'vue';
  * @param {string[]} roles An array of roles to check
  * @returns {boolean} True if all `roles` exist in `tokenRoles`; false otherwise
  */
-// function hasRoles(tokenRoles, roles = []) {
-//   return roles.map(r => tokenRoles.some(t => t === r)).every(x => x === true);
-// }
+function hasRoles(tokenRoles, roles = []) {
+  return roles.map(r => tokenRoles.some(t => t === r)).every(x => x === true);
+}
 
 export default {
   namespaced: true,
@@ -21,14 +19,10 @@ export default {
     createLoginUrl: () => options => Vue.prototype.$keycloak.createLoginUrl(options),
     createLogoutUrl: () => options => Vue.prototype.$keycloak.createLogoutUrl(options),
     fullName: () => Vue.prototype.$keycloak.fullName,
-    isAdmin: () => {
-      return true;
+    hasSilvipcRoles: (_state, getters) => roles => {
+      if (!getters.authenticated) return false;
+      return hasRoles(getters.resourceAccess.silvipc.roles, roles);
     },
-    // isAdmin: (_state, getters) => {
-    //   return true;
-    //   // if (!getters.authenticated) return false;
-    //   // return hasRoles(getters.realmAccess.roles, [RealmRoles.SILVIPC_ADMIN]);
-    // },
     keycloakReady: () => Vue.prototype.$keycloak.ready,
     keycloakSubject: () => Vue.prototype.$keycloak.subject,
     moduleLoaded: () => !!Vue.prototype.$keycloak,

--- a/app/frontend/src/utils/constants.js
+++ b/app/frontend/src/utils/constants.js
@@ -2,3 +2,8 @@ export const ApiRoutes = Object.freeze({
   EMAIL: '/email',
   IPC: '/ipc'
 });
+
+export const SilvipcRoles = Object.freeze({
+  DEVELOPER: 'developer',
+  INSPECTOR: 'inspector'
+});

--- a/app/frontend/src/views/Admin.vue
+++ b/app/frontend/src/views/Admin.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container>
-    <BaseSecure admin>
+    <BaseSecure>
       <h1 class="mt-6 text-center">Admin</h1>
       <transition name="component-fade" mode="out-in">
         <router-view />

--- a/app/frontend/src/views/Dev.vue
+++ b/app/frontend/src/views/Dev.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container>
-    <BaseSecure admin>
+    <BaseSecure>
       <h1 class="mt-6 text-center">Development</h1>
       <v-container>
         <ApiTester class="my-8" />

--- a/app/frontend/src/views/admin/Dev.vue
+++ b/app/frontend/src/views/admin/Dev.vue
@@ -1,10 +1,11 @@
 <template>
   <v-container>
-    <BaseSecure>
-      <h1 class="mt-6 text-center">Development</h1>
-      <v-container>
-        <ApiTester class="my-8" />
-      </v-container>
+    <BaseSecure developer>
+      <router-link :to="{ name: 'Admin'}">
+        <v-btn color="primary" class="mt-5">Back</v-btn>
+      </router-link>
+
+      <ApiTester class="my-8" />
     </BaseSecure>
   </v-container>
 </template>

--- a/app/frontend/src/views/admin/Root.vue
+++ b/app/frontend/src/views/admin/Root.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container>
-    <BaseSecure admin>
+    <BaseSecure>
       <SubmissionsTable class="my-8" />
     </BaseSecure>
   </v-container>

--- a/app/frontend/src/views/admin/Submission.vue
+++ b/app/frontend/src/views/admin/Submission.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container>
-    <BaseSecure admin>
+    <BaseSecure>
       <router-link :to="{ name: 'Admin'}">
         <v-btn color="primary" class="mt-5">Back</v-btn>
       </router-link>

--- a/app/frontend/tests/unit/components/base/BaseSecure.spec.js
+++ b/app/frontend/tests/unit/components/base/BaseSecure.spec.js
@@ -19,7 +19,7 @@ describe('BaseSecure.vue', () => {
       getters: {
         authenticated: () => true,
         createLoginUrl: () => 'test',
-        isAdmin: () => true,
+        hasSilvipcRoles: () => () => true,
         keycloakReady: () => true
       }
     });
@@ -35,7 +35,7 @@ describe('BaseSecure.vue', () => {
       getters: {
         authenticated: () => true,
         createLoginUrl: () => 'test',
-        isAdmin: () => false,
+        hasSilvipcRoles: () => () => false,
         keycloakReady: () => true
       }
     });
@@ -58,7 +58,7 @@ describe('BaseSecure.vue', () => {
       getters: {
         authenticated: () => false,
         createLoginUrl: () => 'test',
-        isAdmin: () => false,
+        hasSilvipcRoles: () => () => false,
         keycloakReady: () => true
       }
     });
@@ -74,7 +74,7 @@ describe('BaseSecure.vue', () => {
       getters: {
         authenticated: () => false,
         createLoginUrl: () => 'test',
-        isAdmin: () => false,
+        hasSilvipcRoles: () => () => false,
         keycloakReady: () => false
       }
     });

--- a/app/frontend/tests/unit/store/modules/auth.getters.spec.js
+++ b/app/frontend/tests/unit/store/modules/auth.getters.spec.js
@@ -1,0 +1,128 @@
+import { cloneDeep } from 'lodash';
+import { createLocalVue } from '@vue/test-utils';
+import Vue from 'vue';
+import Vuex from 'vuex';
+
+import authStore from '@/store/modules/auth';
+import { SilvipcRoles } from '@/utils/constants';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+const zeroUuid = '00000000-0000-0000-0000-000000000000';
+
+describe('auth getters', () => {
+  let authenticated;
+  let roles;
+  let store;
+
+  beforeEach(() => {
+    authenticated = true;
+    roles = [];
+    store = new Vuex.Store(cloneDeep(authStore));
+
+    Object.defineProperty(Vue.prototype, '$keycloak', {
+      configurable: true, // Needed to allow deletions later
+      get() {
+        return {
+          authenticated: authenticated,
+          createLoginUrl: () => 'loginUrl',
+          createLogoutUrl: () => 'logoutUrl',
+          fullName: 'fName',
+          ready: true,
+          subject: zeroUuid,
+          token: 'token',
+          tokenParsed: {
+            realm_access: {},
+            resource_access: {
+              silvipc: {
+                roles: roles
+              }
+            }
+          },
+          userName: 'uName'
+        };
+      }
+    });
+  });
+
+  afterEach(() => {
+    if (Vue.prototype.$keycloak) {
+      delete Vue.prototype.$keycloak;
+    }
+  });
+
+  it('authenticated should return a boolean', () => {
+    expect(store.getters.authenticated).toBeTruthy();
+  });
+
+  it('createLoginUrl should return a string', () => {
+    expect(store.getters.createLoginUrl).toBeTruthy();
+    expect(typeof store.getters.createLoginUrl).toBe('function');
+    expect(store.getters.createLoginUrl()).toMatch('loginUrl');
+  });
+
+  it('createLogoutUrl should return a string', () => {
+    expect(store.getters.createLogoutUrl).toBeTruthy();
+    expect(typeof store.getters.createLogoutUrl).toBe('function');
+    expect(store.getters.createLogoutUrl()).toMatch('logoutUrl');
+  });
+
+  it('fullName should return a string', () => {
+    expect(store.getters.fullName).toBeTruthy();
+    expect(store.getters.fullName).toMatch('fName');
+  });
+
+  it('hasSilvipcRoles should return false if unauthenticated', () => {
+    authenticated = false;
+
+    expect(store.getters.authenticated).toBeFalsy();
+    expect(store.getters.hasSilvipcRoles(roles)).toBeFalsy();
+  });
+
+  it('hasSilvipcRoles should return true when developer exists', () => {
+    authenticated = true;
+    roles = [SilvipcRoles.DEVELOPER];
+
+    expect(store.getters.authenticated).toBeTruthy();
+    expect(store.getters.hasSilvipcRoles(roles)).toBeTruthy();
+  });
+
+  it('keycloakReady should return a boolean', () => {
+    expect(store.getters.keycloakReady).toBeTruthy();
+  });
+
+  it('keycloakSubject should return a string', () => {
+    expect(store.getters.keycloakSubject).toBeTruthy();
+    expect(store.getters.keycloakSubject).toMatch(zeroUuid);
+  });
+
+  it('moduleLoaded should return a boolean', () => {
+    expect(store.getters.moduleLoaded).toBeTruthy();
+  });
+
+  it('realmAccess should return an object', () => {
+    expect(store.getters.realmAccess).toBeTruthy();
+    expect(typeof store.getters.realmAccess).toBe('object');
+  });
+
+  it('resourceAccess should return an object', () => {
+    expect(store.getters.resourceAccess).toBeTruthy();
+    expect(typeof store.getters.resourceAccess).toBe('object');
+  });
+
+  it('token should return a string', () => {
+    expect(store.getters.token).toBeTruthy();
+    expect(store.getters.token).toMatch('token');
+  });
+
+  it('tokenParsed should return an object', () => {
+    expect(store.getters.tokenParsed).toBeTruthy();
+    expect(typeof store.getters.tokenParsed).toBe('object');
+  });
+
+  it('userName should return a string', () => {
+    expect(store.getters.userName).toBeTruthy();
+    expect(store.getters.userName).toMatch('uName');
+  });
+});

--- a/app/frontend/tests/unit/views/admin/Dev.spec.js
+++ b/app/frontend/tests/unit/views/admin/Dev.spec.js
@@ -1,9 +1,11 @@
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import Vuetify from 'vuetify';
 
-import Dev from '@/views/Dev.vue';
+import router from '@/router';
+import Dev from '@/views/admin/Dev.vue';
 
 const localVue = createLocalVue();
+localVue.use(router);
 localVue.use(Vuetify);
 
 describe('Admin.vue', () => {
@@ -13,6 +15,6 @@ describe('Admin.vue', () => {
       stubs: ['ApiTester', 'BaseSecure']
     });
 
-    expect(wrapper.html()).toMatch('Development');
+    expect(wrapper.html()).toMatch('apitester');
   });
 });


### PR DESCRIPTION
This PR changes BaseSecure to take in either the `developer` or `inspector` prop in order to check for authorization.
* Update auth store to check silvipc resource roles
* Update BaseSecure component and props to handle role checking
* Relocate /dev to /admin/dev and enforce developer role check