### PR TITLE
Bugfix hasSilvipcRoles method blocking authenticated no-role access

### DIFF
--- a/app/frontend/src/store/modules/auth.js
+++ b/app/frontend/src/store/modules/auth.js
@@ -21,7 +21,12 @@ export default {
     fullName: () => Vue.prototype.$keycloak.fullName,
     hasSilvipcRoles: (_state, getters) => roles => {
       if (!getters.authenticated) return false;
-      return hasRoles(getters.resourceAccess.silvipc.roles, roles);
+      if (!roles.length) return true; // No roles to check against
+
+      if (getters.resourceAccess.silvipc) {
+        return hasRoles(getters.resourceAccess.silvipc.roles, roles);
+      }
+      return false; // There are roles to check, but nothing in token to check against
     },
     keycloakReady: () => Vue.prototype.$keycloak.ready,
     keycloakSubject: () => Vue.prototype.$keycloak.subject,

--- a/app/frontend/tests/unit/store/modules/auth.getters.spec.js
+++ b/app/frontend/tests/unit/store/modules/auth.getters.spec.js
@@ -80,12 +80,43 @@ describe('auth getters', () => {
     expect(store.getters.hasSilvipcRoles(roles)).toBeFalsy();
   });
 
+  it('hasSilvipcRoles should return true when checking no roles', () => {
+    authenticated = true;
+    roles = [];
+
+    expect(store.getters.authenticated).toBeTruthy();
+    expect(store.getters.hasSilvipcRoles(roles)).toBeTruthy();
+  });
+
   it('hasSilvipcRoles should return true when developer exists', () => {
     authenticated = true;
     roles = [SilvipcRoles.DEVELOPER];
 
     expect(store.getters.authenticated).toBeTruthy();
     expect(store.getters.hasSilvipcRoles(roles)).toBeTruthy();
+  });
+
+  it('hasSilvipcRoles should return false when resource does not exist', () => {
+    authenticated = true;
+    roles = [SilvipcRoles.DEVELOPER];
+
+    // TODO: Find better way to set up keycloak object mock without deleting first
+    delete Vue.prototype.$keycloak;
+    Object.defineProperty(Vue.prototype, '$keycloak', {
+      configurable: true, // Needed to allow deletions later
+      get() {
+        return {
+          authenticated: authenticated,
+          tokenParsed: {
+            realm_access: {},
+            resource_access: {}
+          }
+        };
+      }
+    });
+
+    expect(store.getters.authenticated).toBeTruthy();
+    expect(store.getters.hasSilvipcRoles(roles)).toBeFalsy();
   });
 
   it('keycloakReady should return a boolean', () => {


### PR DESCRIPTION
Authenticated users with no client specific roles were not able to access the admin panel as intended. This bugfix addresses that.