### PR TITLE
Allow note to be added to a status in the same api call.

### DIFF
--- a/app/src/routes/v1/ipc.js
+++ b/app/src/routes/v1/ipc.js
@@ -75,6 +75,7 @@ router.get('/:ipcPlanId/status', keycloak.protect(`${clientId}:inspector`), asyn
 router.post('/:ipcPlanId/status', keycloak.protect(`${clientId}:inspector`), async (req, res, next) => {
   try {
     const createdBy = req.kauth.grant.access_token.content.preferred_username;
+    // the saveInspectionStatus can add a note to the inspection status if the req.body has a note field...
     const result = await dataService.saveInspectionStatus(req.params.ipcPlanId, createdBy, req.body);
     return res.status(201).json(transformService.modelToAPI.inspectionStatus(result));
   } catch (err) {
@@ -95,25 +96,6 @@ router.post('/:ipcPlanId/notes', keycloak.protect(`${clientId}:inspector`), asyn
   try {
     const createdBy = req.kauth.grant.access_token.content.preferred_username;
     const result = await dataService.saveNote(req.params.ipcPlanId, createdBy, req.body);
-    return res.status(201).json(transformService.modelToAPI.note(result));
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.get('/:ipcPlanId/status/:inspectionStatusId/notes', keycloak.protect(`${clientId}:inspector`), async (req, res, next) => {
-  try {
-    const result = await dataService.getNotes(req.params.ipcPlanId, req.params.inspectionStatusId);
-    return res.status(200).json(transformService.modelToAPI.notes(result));
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.post('/:ipcPlanId/status/:inspectionStatusId/notes', keycloak.protect(`${clientId}:inspector`), async (req, res, next) => {
-  try {
-    const createdBy = req.kauth.grant.access_token.content.preferred_username;
-    const result = await dataService.saveNote(req.params.ipcPlanId, createdBy, req.body, req.params.inspectionStatusId);
     return res.status(201).json(transformService.modelToAPI.note(result));
   } catch (err) {
     next(err);

--- a/app/src/services/transformService.js
+++ b/app/src/services/transformService.js
@@ -69,14 +69,19 @@ const transformService = {
 
     inspectionStatus: (obj) => {
       if (obj && !Array.isArray(obj)) {
-        return {...obj.dataValues};
+        let notes = [];
+        if (obj.Notes) {
+          notes = obj.Notes.map(c => { return {...c.dataValues}; });
+        }
+        const status = {...obj.dataValues, notes: notes};
+        return status;
       }
       return {};
     },
 
     inspectionStatuses: (obj) => {
       if (obj && Array.isArray(obj)) {
-        return obj.map(x => { return {...x.dataValues}; });
+        return obj.map(x => { return transformService.modelToAPI.inspectionStatus(x); });
       }
       return [];
     },
@@ -138,12 +143,8 @@ const transformService = {
     const contacts = ipcPlan.Contacts.map(c => {
       return {...c.dataValues};
     });
-    const inspectionStatuses = ipcPlan.InspectionStatuses.map(s => {
-      return {...s.dataValues};
-    });
-    const notes = ipcPlan.Notes.map(s => {
-      return {...s.dataValues};
-    });
+    const inspectionStatuses = transformService.modelToAPI.inspectionStatuses(ipcPlan.InspectionStatuses);
+    const notes = transformService.modelToAPI.notes(ipcPlan.Notes);
     delete ipcPlan.Notes;
     delete ipcPlan.InspectionStatuses;
     delete ipcPlan.Contacts;


### PR DESCRIPTION
Remove the status/notes api, related notes are returned when status is fetched.
Notes are at the top level of the return (with business, location, ipcPlan, etc) AND in the InspectionStatuses if they relate to one.

I removed what are no extraneous api calls (for adding/getting notes per status).  All that functionality is available elsewhere.

<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->