### PR TITLE
Throw Problem on save errors, handle Inspection Date timezone on backend.

### DIFF
--- a/app/src/models/index.js
+++ b/app/src/models/index.js
@@ -28,5 +28,7 @@ db.Sequelize = Sequelize;
 
 db.isNotFoundError = e => e && e instanceof Sequelize.EmptyResultError;
 db.isSyntaxError = e => e && e instanceof Sequelize.DatabaseError && /syntax/.test(e.message);
+db.isRequiredFieldError = e => e && e instanceof Sequelize.ValidationError && /notNull/.test(e.message);
+db.isRequiredFieldErrorMessage = e => db.isRequiredFieldError(e) ? e.message.split(':')[1] : '';
 
 module.exports = db;

--- a/app/src/services/transformService.js
+++ b/app/src/services/transformService.js
@@ -162,9 +162,8 @@ const transformService = {
 
     const biz = {...ipcPlan.Business.dataValues};
     delete ipcPlan.Business;
-    const inspectionStatuses = ipcPlan.InspectionStatuses.map(s => {
-      return {...s.dataValues};
-    });
+    const currentStatus = ipcPlan.InspectionStatuses[0];
+    const inspectionStatuses = [{...currentStatus.dataValues}];
     delete ipcPlan.InspectionStatuses;
 
     return transformService.ipcResult(biz, undefined, ipcPlan, undefined, inspectionStatuses);


### PR DESCRIPTION
Handle incoming inspectionDate and force to save with local timezone offset.
Throw problems on save, do not just log the error.
For /admin (ipc meta search), do not return all inspection status records, just the current one, so it can be retrieved like result.inspectionStatuses[0].

<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality) 
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->