### PR TITLE
Add Audit Table and Trigger function

### DIFF
--- a/app/src/migrations/20200511000000-7-updated-by-fields-for-audit.js
+++ b/app/src/migrations/20200511000000-7-updated-by-fields-for-audit.js
@@ -1,0 +1,57 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.addColumn(
+          'business',
+          'updatedBy',
+          {
+            allowNull: true,
+            comment: 'User updating the record',
+            type: Sequelize.STRING(255),
+            unique: false
+          },
+          { transaction: t }),
+        queryInterface.addColumn(
+          'contact',
+          'updatedBy',
+          {
+            allowNull: true,
+            comment: 'User updating the record',
+            type: Sequelize.STRING(255),
+            unique: false
+          },
+          { transaction: t }),
+        queryInterface.addColumn(
+          'location',
+          'updatedBy',
+          {
+            allowNull: true,
+            comment: 'User updating the record',
+            type: Sequelize.STRING(255),
+            unique: false
+          },
+          { transaction: t })
+      ]);
+    });
+  },
+
+  down: queryInterface => {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.removeColumn(
+          'business',
+          'updatedBy',
+          { transaction: t }),
+        queryInterface.removeColumn(
+          'contact',
+          'updatedBy',
+          { transaction: t }),
+        queryInterface.removeColumn(
+          'location',
+          'updatedBy',
+          { transaction: t }),
+      ]);
+    });
+  }
+};

--- a/app/src/migrations/20200511000001-7-audit-trigger.js
+++ b/app/src/migrations/20200511000001-7-audit-trigger.js
@@ -1,0 +1,137 @@
+module.exports = {
+  up: (queryInterface) => {
+    return queryInterface.sequelize.transaction((t) => {
+      return queryInterface.sequelize.query('CREATE TABLE logged_actions (\n' +
+        '    schema_name text NOT NULL,\n' +
+        '    TABLE_NAME text NOT NULL,\n' +
+        '    user_name text,\n' +
+        '    action_tstamp TIMESTAMP WITH TIME zone NOT NULL DEFAULT CURRENT_TIMESTAMP,\n' +
+        '    action TEXT NOT NULL CHECK (action IN (\'I\',\'D\',\'U\')),\n' +
+        '    original_data text,\n' +
+        '    new_data text,\n' +
+        '    query text\n' +
+        ') WITH (fillfactor=100)',
+      {
+        transaction: t
+      }).then(() => {
+        return queryInterface.sequelize.query('REVOKE ALL ON logged_actions FROM public;',
+          {
+            transaction: t
+          });
+      }).then(() => {
+        return queryInterface.sequelize.query('GRANT SELECT ON logged_actions TO public;',
+          {
+            transaction: t
+          });
+      }).then(() => {
+        return queryInterface.sequelize.query('CREATE INDEX logged_actions_schema_table_idx ON logged_actions(((schema_name||\'.\'||TABLE_NAME)::TEXT));',
+          {
+            transaction: t
+          });
+      }).then(() => {
+        return queryInterface.sequelize.query('CREATE INDEX logged_actions_action_tstamp_idx ON logged_actions(action_tstamp);',
+          {
+            transaction: t
+          });
+      }).then(() => {
+        return queryInterface.sequelize.query('CREATE INDEX logged_actions_action_idx ON logged_actions(action);',
+          {
+            transaction: t
+          });
+      }).then(() => {
+        return queryInterface.sequelize.query('CREATE OR REPLACE FUNCTION if_modified_func() RETURNS TRIGGER AS $body$\n' +
+          'DECLARE\n' +
+          '    v_old_data TEXT;\n' +
+          '    v_new_data TEXT;\n' +
+          'BEGIN\n' +
+          '    /* This dance with casting the NEW and OLD values to a ROW is not necessary in pg 9.0+ */\n' +
+          '    IF (TG_OP = \'UPDATE\') THEN\n' +
+          '        v_old_data := ROW(OLD.*);\n' +
+          '        v_new_data := ROW(NEW.*);\n' +
+          '        INSERT INTO logged_actions (schema_name,table_name,user_name,action,original_data,new_data,query) \n' +
+          '        VALUES (TG_TABLE_SCHEMA::TEXT,TG_TABLE_NAME::TEXT,session_user::TEXT,substring(TG_OP,1,1),v_old_data,v_new_data, current_query());\n' +
+          '        RETURN NEW;\n' +
+          '    ELSIF (TG_OP = \'DELETE\') THEN\n' +
+          '        v_old_data := ROW(OLD.*);\n' +
+          '        INSERT INTO logged_actions (schema_name,table_name,user_name,action,original_data,query)\n' +
+          '        VALUES (TG_TABLE_SCHEMA::TEXT,TG_TABLE_NAME::TEXT,session_user::TEXT,substring(TG_OP,1,1),v_old_data, current_query());\n' +
+          '        RETURN OLD;\n' +
+          '    ELSIF (TG_OP = \'INSERT\') THEN\n' +
+          '        v_new_data := ROW(NEW.*);\n' +
+          '        INSERT INTO logged_actions (schema_name,table_name,user_name,action,new_data,query)\n' +
+          '        VALUES (TG_TABLE_SCHEMA::TEXT,TG_TABLE_NAME::TEXT,session_user::TEXT,substring(TG_OP,1,1),v_new_data, current_query());\n' +
+          '        RETURN NEW;\n' +
+          '    ELSE\n' +
+          '        RAISE WARNING \'[IF_MODIFIED_FUNC] - Other action occurred: %, at %\',TG_OP,now();\n' +
+          '        RETURN NULL;\n' +
+          '    END IF;\n' +
+          ' \n' +
+          'EXCEPTION\n' +
+          '    WHEN data_exception THEN\n' +
+          '        RAISE WARNING \'[IF_MODIFIED_FUNC] - UDF ERROR [DATA EXCEPTION] - SQLSTATE: %, SQLERRM: %\',SQLSTATE,SQLERRM;\n' +
+          '        RETURN NULL;\n' +
+          '    WHEN unique_violation THEN\n' +
+          '        RAISE WARNING \'[IF_MODIFIED_FUNC] - UDF ERROR [UNIQUE] - SQLSTATE: %, SQLERRM: %\',SQLSTATE,SQLERRM;\n' +
+          '        RETURN NULL;\n' +
+          '    WHEN OTHERS THEN\n' +
+          '        RAISE WARNING \'[IF_MODIFIED_FUNC] - UDF ERROR [OTHER] - SQLSTATE: %, SQLERRM: %\',SQLSTATE,SQLERRM;\n' +
+          '        RETURN NULL;\n' +
+          'END;\n' +
+          '$body$\n' +
+          'LANGUAGE plpgsql\n' +
+          'SECURITY DEFINER\n' +
+          'SET search_path = pg_catalog, public;\n',
+        {
+          transaction: t
+        }).then(() => {
+          return queryInterface.sequelize.query('CREATE TRIGGER business_audit\n' +
+            'AFTER UPDATE OR DELETE ON business\n' +
+            'FOR EACH ROW EXECUTE PROCEDURE if_modified_func()',
+          {
+            transaction: t
+          });
+        }).then(() => {
+          return queryInterface.sequelize.query('CREATE TRIGGER contact_audit\n' +
+            'AFTER UPDATE OR DELETE ON contact\n' +
+            'FOR EACH ROW EXECUTE PROCEDURE if_modified_func()',
+          {
+            transaction: t
+          });
+        }).then(() => {
+          return queryInterface.sequelize.query('CREATE TRIGGER location_audit\n' +
+            'AFTER UPDATE OR DELETE ON location\n' +
+            'FOR EACH ROW EXECUTE PROCEDURE if_modified_func()',
+          {
+            transaction: t
+          });
+        });
+      });
+    });
+  },
+
+  down: queryInterface => {
+    return queryInterface.sequelize.transaction((t) => {
+      return queryInterface.sequelize.query('drop trigger if exists location_audit ON location cascade;',
+        {transaction: t})
+        .then(() => {
+          return queryInterface.sequelize.query('drop trigger if exists contact_audit ON contact cascade;', {
+            transaction: t
+          });
+        })
+        .then(() => {
+          return queryInterface.sequelize.query('drop trigger if exists business_audit ON business cascade;', {
+            transaction: t
+          });
+        })
+        .then(() => {
+          return queryInterface.sequelize.query('drop function if exists if_modified_func() cascade;', {
+            transaction: t
+          });
+        }).then(() => {
+          return queryInterface.dropTable('logged_actions', {
+            transaction: t
+          });
+        });
+    });
+  }
+};

--- a/app/src/models/business.js
+++ b/app/src/models/business.js
@@ -44,6 +44,11 @@ module.exports = (sequelize, DataTypes) => {
       comment: 'Postal code',
       type: DataTypes.STRING(30),
       unique: false
+    },
+    updatedBy: {
+      allowNull: false,
+      type: DataTypes.STRING(255),
+      unique: false
     }
   }, {
     comment: 'List of all businesses',

--- a/app/src/models/business.js
+++ b/app/src/models/business.js
@@ -46,7 +46,7 @@ module.exports = (sequelize, DataTypes) => {
       unique: false
     },
     updatedBy: {
-      allowNull: false,
+      allowNull: true,
       type: DataTypes.STRING(255),
       unique: false
     }

--- a/app/src/models/contact.js
+++ b/app/src/models/contact.js
@@ -44,6 +44,11 @@ module.exports = (sequelize, DataTypes) => {
       comment: 'Contact email address',
       type: DataTypes.STRING(255),
       unique: false
+    },
+    updatedBy: {
+      allowNull: false,
+      type: DataTypes.STRING(255),
+      unique: false
     }
   }, {
     comment: 'List of all contacts',

--- a/app/src/models/contact.js
+++ b/app/src/models/contact.js
@@ -46,7 +46,7 @@ module.exports = (sequelize, DataTypes) => {
       unique: false
     },
     updatedBy: {
-      allowNull: false,
+      allowNull: true,
       type: DataTypes.STRING(255),
       unique: false
     }

--- a/app/src/models/location.js
+++ b/app/src/models/location.js
@@ -120,7 +120,7 @@ module.exports = (sequelize, DataTypes) => {
       unique: false
     },
     updatedBy: {
-      allowNull: false,
+      allowNull: true,
       type: DataTypes.STRING(255),
       unique: false
     }

--- a/app/src/models/location.js
+++ b/app/src/models/location.js
@@ -118,6 +118,11 @@ module.exports = (sequelize, DataTypes) => {
       comment: 'Number (integer) of workers working at the location',
       type: DataTypes.INTEGER,
       unique: false
+    },
+    updatedBy: {
+      allowNull: false,
+      type: DataTypes.STRING(255),
+      unique: false
     }
   },
   {

--- a/app/src/routes/v1/ipc.js
+++ b/app/src/routes/v1/ipc.js
@@ -102,4 +102,17 @@ router.post('/:ipcPlanId/notes', keycloak.protect(`${clientId}:inspector`), asyn
   }
 });
 
+router.put('/:ipcPlanId', keycloak.protect(`${clientId}:inspector`), async (req, res, next) => {
+  try {
+    const updatedBy = req.kauth.grant.access_token.content.preferred_username;
+    const xform = transformService.apiToModel.postToIPCPlan(req.body);
+    const result = await dataService.update(xform.business, xform.contacts, xform.ipcPlan, xform.location, updatedBy);
+    const data = transformService.modelToAPI.ipcPlanToPost(result);
+    return res.status(200).json(data);
+  } catch (err) {
+    next(err);
+  }
+});
+
+
 module.exports = router;


### PR DESCRIPTION
Hook business, contact, location to audit on update/delete.
Required adding an updatedBy userstamp on each of the tables/models.  Allows us to see who actually changed the records in the audit record.

Add a wholesale PUT/Update function similar to the IPC POST, only update specific fields in location for now (start date, end date).

Based on [Audit Trigger PostgreSQL Wiki](https://wiki.postgresql.org/wiki/Audit_trigger).

<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->