### PR TITLE
show inspection date in local timezone and inspector on submissions table

### DIFF
--- a/app/frontend/src/components/admin/StatusTable.vue
+++ b/app/frontend/src/components/admin/StatusTable.vue
@@ -26,7 +26,7 @@
 
       <template v-slot:item.inspectorName="{ item }">{{ item.inspectorName }}</template>
 
-      <template v-slot:item.inspectionDate="{ item }">{{ formatDate(item.inspectionDate) }}</template>
+      <template v-slot:item.inspectionDate="{ item }">{{ getLocalDateFromUtc(item.inspectionDate) }}</template>
     </v-data-table>
   </v-container>
 </template>
@@ -61,6 +61,9 @@ export default {
   methods: {
     formatDate(date) {
       return date ? new Date(date).toLocaleString() : '';
+    },
+    getLocalDateFromUtc(date){
+      return date ? new Date(date).toLocaleDateString() : '';
     },
     getData() {
       ipcService

--- a/app/frontend/src/components/admin/SubmissionsTable.vue
+++ b/app/frontend/src/components/admin/SubmissionsTable.vue
@@ -64,6 +64,7 @@ export default {
       headers: [
         { text: 'Submitted', value: 'created' },
         { text: 'Status', align: 'start', value: 'inspectionStatus' },
+        { text: 'Assigned', align: 'start', value: 'inspectorName' },
         { text: 'Business Name', align: 'start', value: 'name' },
         { text: 'Confirmation ID', align: 'start', value: 'confirmationId' },
         { text: 'Download', value: 'download', sortable: false },
@@ -107,6 +108,8 @@ export default {
           const data = response.data;
           const submissions = Object.keys(data).map(k => {
             let submission = data[k];
+            let inspectorName = (submission.inspectionStatuses[0].inspectorName !== null) ? submission.inspectionStatuses[0].inspectorName : ' - ';
+
             return {
               ipcPlanId: submission.ipcPlan.ipcPlanId,
               pdf: submission.ipcPlan.ipcPlanId,
@@ -114,6 +117,7 @@ export default {
               created: this.formatDate(submission.ipcPlan.createdAt),
               confirmationId: submission.confirmationId,
               inspectionStatus: submission.inspectionStatuses[0].status,
+              inspectorName: inspectorName,
             };
           });
           if (!submissions.length) {

--- a/app/frontend/src/components/admin/SubmissionsTable.vue
+++ b/app/frontend/src/components/admin/SubmissionsTable.vue
@@ -108,7 +108,7 @@ export default {
           const data = response.data;
           const submissions = Object.keys(data).map(k => {
             let submission = data[k];
-            let inspectorName = (submission.inspectionStatuses[0].inspectorName !== null) ? submission.inspectionStatuses[0].inspectorName : ' - ';
+            const inspectorName = submission.inspectionStatuses[0].inspectorName ? submission.inspectionStatuses[0].inspectorName : ' - ';
 
             return {
               ipcPlanId: submission.ipcPlan.ipcPlanId,

--- a/app/frontend/src/components/admin/inspection/InspectionPanel.vue
+++ b/app/frontend/src/components/admin/inspection/InspectionPanel.vue
@@ -284,7 +284,7 @@ export default {
     },
     showInspector() { return [this.statuses.ASSIGNED, this.statuses.SCHEDULED, this.statuses.FOLLOWUP].includes(this.statusToSet); },
     showInspectionDate() { return [this.statuses.SCHEDULED, this.statuses.FOLLOWUP].includes(this.statusToSet); },
-    inspectionDateDisplay() { return this.currentStatus.inspectionDate ? moment(this.currentStatus.inspectionDatmomente).format('MMMM D YYYY') : 'N/A'; },
+    inspectionDateDisplay() { return this.currentStatus.inspectionDate ? moment(this.currentStatus.inspectionDate).format('MMMM D YYYY') : 'N/A'; },
     showGrade() { return [this.statuses.COMPLETED, this.statuses.FOLLOWUP].includes(this.statusToSet); }
   },
   methods: {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

1 - show 'Inspection Date' in local timezone on Inspection History table.
The inspection date is stored as a UTC timestamp in the db.
On the pop up history table, it should be converted back to local timezone (ie -7 or -8 hrs)

2 - show assigned inspector on admin>submissions table

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->