### PR TITLE
add operation type to pdf data object

### DIFF
--- a/app/src/components/ipcPlanPdf.js
+++ b/app/src/components/ipcPlanPdf.js
@@ -25,8 +25,10 @@ module.exports = {
 
     // quick fix: update operationType with display name
     const OperationTypes = constants.OperationTypes;
+    // add operation Type to ipcPlanData
+    ipcPlanData.ipcPlan.operationType = OperationTypes[ipcPlanData.ipcPlan.operationType];
 
-    body.data = { ...ipcPlanData, ipcPlan : {operationType: OperationTypes[ipcPlanData.ipcPlan.operationType] } };
+    body.data = { ...ipcPlanData  };
 
     return await cdogsService.templateRender(templateId, body);
   }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

fixes bug created in pr-111
this fix should now be adding the operationType value to the pdf data object.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->